### PR TITLE
Add custom User model

### DIFF
--- a/pylab/accounts/forms.py
+++ b/pylab/accounts/forms.py
@@ -2,13 +2,32 @@ from django import forms
 from django.utils.translation import ugettext_lazy as _
 import django.contrib.auth.models as auth_models
 
+import pylab.accounts.models as accounts_models
 
-class SettingsForm(forms.ModelForm):
+
+class UserProfileForm(forms.ModelForm):
+    first_name = forms.CharField(label=_('First name'), required=False)
+    last_name = forms.CharField(label=_('Last name'), required=False)
+    email = forms.EmailField(label=_('Email address'), required=False)
+
     class Meta:
-        model = auth_models.User
-        fields = ('first_name', 'last_name', 'email')
+        model = accounts_models.UserProfile
+        fields = ('first_name', 'last_name', 'email', 'language')
         help_texts = {
             'email': _(
                 "Bus naudojamas komunikacijai. Jei pageidaujate negauti jokių laiškų, palikite šį lauką tuščią."
             ),
         }
+
+    def __init__(self, *args, **kwargs):
+        super(UserProfileForm, self).__init__(*args, **kwargs)
+        self.fields['email'].initial = self.instance.user.email
+        self.fields['first_name'].initial = self.instance.user.first_name
+        self.fields['last_name'].initial = self.instance.user.last_name
+
+    def save(self, *args, **kwargs):
+        super(UserProfileForm, self).save(*args, **kwargs)
+        self.instance.user.email = self.cleaned_data.get('email')
+        self.instance.user.first_name = self.cleaned_data.get('first_name')
+        self.instance.user.last_name = self.cleaned_data.get('last_name')
+        self.instance.user.save()

--- a/pylab/accounts/migrations/0001_initial.py
+++ b/pylab/accounts/migrations/0001_initial.py
@@ -2,42 +2,31 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import django.utils.timezone
-import django.core.validators
-import django.contrib.auth.models
+from django.conf import settings
+
+
+
+def create_userprofiles_for_each_user(apps, schema_editor):
+    User = apps.get_model("auth", "User")
+    UserProfile = apps.get_model("accounts", "UserProfile")
+    for user in User.objects.all():
+        UserProfile.objects.get_or_create(user=user)
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('auth', '0006_require_contenttypes_0002'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='User',
+            name='UserProfile',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', auto_created=True, primary_key=True, serialize=False)),
-                ('password', models.CharField(max_length=128, verbose_name='password')),
-                ('last_login', models.DateTimeField(null=True, blank=True, verbose_name='last login')),
-                ('is_superuser', models.BooleanField(help_text='Designates that this user has all permissions without explicitly assigning them.', default=False, verbose_name='superuser status')),
-                ('username', models.CharField(max_length=30, help_text='Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only.', validators=[django.core.validators.RegexValidator('^[\\w.@+-]+$', 'Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters.', 'invalid')], error_messages={'unique': 'A user with that username already exists.'}, verbose_name='username', unique=True)),
-                ('first_name', models.CharField(max_length=30, blank=True, verbose_name='first name')),
-                ('last_name', models.CharField(max_length=30, blank=True, verbose_name='last name')),
-                ('email', models.EmailField(max_length=254, blank=True, verbose_name='email address')),
-                ('is_staff', models.BooleanField(help_text='Designates whether the user can log into this admin site.', default=False, verbose_name='staff status')),
-                ('is_active', models.BooleanField(help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', default=True, verbose_name='active')),
-                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
-                ('language', models.CharField(default='LT', verbose_name='language', max_length=2, choices=[('LT', 'Lithuanian'), ('EN', 'English')])),
-                ('groups', models.ManyToManyField(blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', related_name='user_set', to='auth.Group', related_query_name='user', verbose_name='groups')),
-                ('user_permissions', models.ManyToManyField(blank=True, help_text='Specific permissions for this user.', related_name='user_set', to='auth.Permission', related_query_name='user', verbose_name='user permissions')),
-            ],
-            options={
-                'verbose_name_plural': 'users',
-                'verbose_name': 'user',
-            },
-            managers=[
-                ('objects', django.contrib.auth.models.UserManager()),
+                ('id', models.AutoField(verbose_name='ID', serialize=False, primary_key=True, auto_created=True)),
+                ('language', models.CharField(default='lt', verbose_name='language', max_length=7, choices=[('lt', 'Lithuanian'), ('en', 'English')])),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
         ),
+        migrations.RunPython(create_userprofiles_for_each_user),
     ]

--- a/pylab/accounts/migrations/0001_initial.py
+++ b/pylab/accounts/migrations/0001_initial.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+import django.core.validators
+import django.contrib.auth.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0006_require_contenttypes_0002'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='User',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', auto_created=True, primary_key=True, serialize=False)),
+                ('password', models.CharField(max_length=128, verbose_name='password')),
+                ('last_login', models.DateTimeField(null=True, blank=True, verbose_name='last login')),
+                ('is_superuser', models.BooleanField(help_text='Designates that this user has all permissions without explicitly assigning them.', default=False, verbose_name='superuser status')),
+                ('username', models.CharField(max_length=30, help_text='Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only.', validators=[django.core.validators.RegexValidator('^[\\w.@+-]+$', 'Enter a valid username. This value may contain only letters, numbers and @/./+/-/_ characters.', 'invalid')], error_messages={'unique': 'A user with that username already exists.'}, verbose_name='username', unique=True)),
+                ('first_name', models.CharField(max_length=30, blank=True, verbose_name='first name')),
+                ('last_name', models.CharField(max_length=30, blank=True, verbose_name='last name')),
+                ('email', models.EmailField(max_length=254, blank=True, verbose_name='email address')),
+                ('is_staff', models.BooleanField(help_text='Designates whether the user can log into this admin site.', default=False, verbose_name='staff status')),
+                ('is_active', models.BooleanField(help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', default=True, verbose_name='active')),
+                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
+                ('language', models.CharField(default='LT', verbose_name='language', max_length=2, choices=[('LT', 'Lithuanian'), ('EN', 'English')])),
+                ('groups', models.ManyToManyField(blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', related_name='user_set', to='auth.Group', related_query_name='user', verbose_name='groups')),
+                ('user_permissions', models.ManyToManyField(blank=True, help_text='Specific permissions for this user.', related_name='user_set', to='auth.Permission', related_query_name='user', verbose_name='user permissions')),
+            ],
+            options={
+                'verbose_name_plural': 'users',
+                'verbose_name': 'user',
+            },
+            managers=[
+                ('objects', django.contrib.auth.models.UserManager()),
+            ],
+        ),
+    ]

--- a/pylab/accounts/models.py
+++ b/pylab/accounts/models.py
@@ -1,56 +1,16 @@
-import autoslug
-from django_extensions.db.fields import CreationDateTimeField, ModificationDateTimeField
-
+import django.contrib.auth.models as auth_models
 from django.conf import settings
-from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin, UserManager
-from django.core import validators
-from django.core.urlresolvers import reverse
 from django.db import models
-from django.utils import timezone
+from django.db.models.signals import post_save
+from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
 
 
-
-class User(AbstractBaseUser, PermissionsMixin):
-    """Custom user model based on default Django user model."""
-    username = models.CharField(_('username'), max_length=30, unique=True,
-        help_text=_('Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only.'),
-        validators=[validators.RegexValidator(r'^[\w.@+-]+$', _('Enter a valid username. This value may contain only '
-                                                                'letters, numbers and @/./+/-/_ chars.'), 'invalid'),],
-        error_messages={'unique': _("A user with that username already exists.")})
-    first_name = models.CharField(_('first name'), max_length=30, blank=True)
-    last_name = models.CharField(_('last name'), max_length=30, blank=True)
-    email = models.EmailField(_('email address'), blank=True)
-    is_staff = models.BooleanField(_('staff status'), default=False,
-        help_text=_('Designates whether the user can log into this admin site.'))
-    is_active = models.BooleanField(_('active'), default=True,
-        help_text=_('Designates whether this user should be treated as '
-                    'active. Unselect this instead of deleting accounts.'))
-    date_joined = models.DateTimeField(_('date joined'), default=timezone.now)
+class UserProfile(models.Model):
+    user = models.OneToOneField(auth_models.User)
     language = models.CharField(_('language'), max_length=7, choices=settings.AVAILABLE_LANGUAGES, default='lt')
 
-    objects = UserManager()
-
-    USERNAME_FIELD = 'username'
-    REQUIRED_FIELDS = ['email']
-
-    class Meta:
-        verbose_name = _('user')
-        verbose_name_plural = _('users')
-
-    def get_full_name(self):
-        """
-        Returns the first_name plus the last_name, with a space in between.
-        """
-        full_name = '%s %s' % (self.first_name, self.last_name)
-        return full_name.strip()
-
-    def get_short_name(self):
-        "Returns the short name for the user."
-        return self.first_name
-
-    def email_user(self, subject, message, from_email=None, **kwargs):
-        """
-        Sends an email to this User.
-        """
-        send_mail(subject, message, from_email, [self.email], **kwargs)
+@receiver(post_save, sender=auth_models.User)
+def create_userprofile_for_new_user(sender, **kwargs):
+    user = kwargs.get('instance')
+    UserProfile.objects.get_or_create(user=user)

--- a/pylab/accounts/models.py
+++ b/pylab/accounts/models.py
@@ -1,0 +1,56 @@
+import autoslug
+from django_extensions.db.fields import CreationDateTimeField, ModificationDateTimeField
+
+from django.conf import settings
+from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin, UserManager
+from django.core import validators
+from django.core.urlresolvers import reverse
+from django.db import models
+from django.utils import timezone
+from django.utils.translation import ugettext_lazy as _
+
+
+
+class User(AbstractBaseUser, PermissionsMixin):
+    """Custom user model based on default Django user model."""
+    username = models.CharField(_('username'), max_length=30, unique=True,
+        help_text=_('Required. 30 characters or fewer. Letters, digits and @/./+/-/_ only.'),
+        validators=[validators.RegexValidator(r'^[\w.@+-]+$', _('Enter a valid username. This value may contain only '
+                                                                'letters, numbers and @/./+/-/_ chars.'), 'invalid'),],
+        error_messages={'unique': _("A user with that username already exists.")})
+    first_name = models.CharField(_('first name'), max_length=30, blank=True)
+    last_name = models.CharField(_('last name'), max_length=30, blank=True)
+    email = models.EmailField(_('email address'), blank=True)
+    is_staff = models.BooleanField(_('staff status'), default=False,
+        help_text=_('Designates whether the user can log into this admin site.'))
+    is_active = models.BooleanField(_('active'), default=True,
+        help_text=_('Designates whether this user should be treated as '
+                    'active. Unselect this instead of deleting accounts.'))
+    date_joined = models.DateTimeField(_('date joined'), default=timezone.now)
+    language = models.CharField(_('language'), max_length=7, choices=settings.AVAILABLE_LANGUAGES, default='lt')
+
+    objects = UserManager()
+
+    USERNAME_FIELD = 'username'
+    REQUIRED_FIELDS = ['email']
+
+    class Meta:
+        verbose_name = _('user')
+        verbose_name_plural = _('users')
+
+    def get_full_name(self):
+        """
+        Returns the first_name plus the last_name, with a space in between.
+        """
+        full_name = '%s %s' % (self.first_name, self.last_name)
+        return full_name.strip()
+
+    def get_short_name(self):
+        "Returns the short name for the user."
+        return self.first_name
+
+    def email_user(self, subject, message, from_email=None, **kwargs):
+        """
+        Sends an email to this User.
+        """
+        send_mail(subject, message, from_email, [self.email], **kwargs)

--- a/pylab/accounts/tests/test_settings.py
+++ b/pylab/accounts/tests/test_settings.py
@@ -2,6 +2,8 @@ import django_webtest
 
 import django.contrib.auth.models as auth_models
 
+import pylab.accounts.models as accounts_models
+
 
 class SettingsTests(django_webtest.WebTest):
     def setUp(self):
@@ -13,8 +15,10 @@ class SettingsTests(django_webtest.WebTest):
         resp.form['first_name'] = 'My'
         resp.form['last_name'] = 'Name'
         resp.form['email'] = ''
+        resp.form['language'] = 'en'
         resp = resp.form.submit()
         self.assertEqual(resp.status_int, 302)
         self.assertEqual(list(auth_models.User.objects.values_list('first_name', 'last_name', 'email')), [
             ('My', 'Name', ''),
         ])
+        self.assertEqual(list(accounts_models.UserProfile.objects.values_list('language')), [('en',),])

--- a/pylab/accounts/views.py
+++ b/pylab/accounts/views.py
@@ -29,13 +29,13 @@ def logout(request):
 @login_required
 def settings(request):
     if request.method == 'POST':
-        form = accounts_forms.SettingsForm(request.POST, instance=request.user)
+        form = accounts_forms.UserProfileForm(request.POST, instance=request.user.userprofile)
         if form.is_valid():
             form.save()
             messages.success(request, ugettext("Nustatymai buvo sėkimingai išsaugoti."))
             return redirect('accounts_settings')
     else:
-        form = accounts_forms.SettingsForm(instance=request.user)
+        form = accounts_forms.UserProfileForm(instance=request.user.userprofile)
     return render(request, 'accounts/settings.html', {
         'form': formrenderer.render(request, form, title=ugettext("Profilio nustatymai"), submit=ugettext("Saugoti")),
     })

--- a/pylab/settings/base.py
+++ b/pylab/settings/base.py
@@ -18,9 +18,6 @@ STATIC_URL = '/static/'
 STATIC_ROOT = str(PROJECT_DIR / 'var/www/static')
 LANGUAGE_CODE = 'en'
 
-# Custom user model https://docs.djangoproject.com/en/stable/topics/auth/customizing/#substituting-a-custom-user-model
-AUTH_USER_MODEL = 'accounts.User'
-
 # pylab constant used for language choice field
 ugettext = lambda s: s
 AVAILABLE_LANGUAGES = (

--- a/pylab/settings/base.py
+++ b/pylab/settings/base.py
@@ -18,6 +18,16 @@ STATIC_URL = '/static/'
 STATIC_ROOT = str(PROJECT_DIR / 'var/www/static')
 LANGUAGE_CODE = 'en'
 
+# Custom user model https://docs.djangoproject.com/en/stable/topics/auth/customizing/#substituting-a-custom-user-model
+AUTH_USER_MODEL = 'accounts.User'
+
+# pylab constant used for language choice field
+ugettext = lambda s: s
+AVAILABLE_LANGUAGES = (
+    ('lt', ugettext('Lithuanian')),
+    ('en', ugettext('English')),
+)
+
 INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.contenttypes',

--- a/pylab/website/models.py
+++ b/pylab/website/models.py
@@ -1,16 +1,16 @@
 import autoslug
 from django_extensions.db.fields import CreationDateTimeField, ModificationDateTimeField
 
-from django.conf import settings
-from django.core.urlresolvers import reverse
+import django.contrib.auth.models as auth_models
 from django.db import models
+from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
 
 class Project(models.Model):
     created = CreationDateTimeField()
     modified = ModificationDateTimeField()
-    author = models.ForeignKey(settings.AUTH_USER_MODEL)
+    author = models.ForeignKey(auth_models.User)
     slug = autoslug.AutoSlugField(populate_from='title')
     title = models.CharField(_("Title"), max_length=255)
     description = models.TextField(_("Description"))

--- a/pylab/website/models.py
+++ b/pylab/website/models.py
@@ -1,16 +1,16 @@
 import autoslug
 from django_extensions.db.fields import CreationDateTimeField, ModificationDateTimeField
 
-import django.contrib.auth.models as auth_models
-from django.db import models
+from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 
 class Project(models.Model):
     created = CreationDateTimeField()
     modified = ModificationDateTimeField()
-    author = models.ForeignKey(auth_models.User)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL)
     slug = autoslug.AutoSlugField(populate_from='title')
     title = models.CharField(_("Title"), max_length=255)
     description = models.TextField(_("Description"))


### PR DESCRIPTION
The new custom User model is based on django.contrib.auth.models.User. Custom
User model was extended by adding language field.

All migration history was purged as sugested in first warning message here:
https://docs.djangoproject.com/en/1.8/topics/auth/customizing/#substituting-a-custom-user-model

settings.base.AVAILABLE_LANGUAGES tuple was defined for usage in form choice
fields. The titles in this tuple should be localised.