### PR TITLE
Add static about page

### DIFF
--- a/pylab/locale/lt/LC_MESSAGES/django.po
+++ b/pylab/locale/lt/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-27 03:04-0500\n"
+"POT-Creation-Date: 2015-07-27 06:02-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -66,13 +66,23 @@ msgstr "Python dirbtuvių politika"
 
 #: website/templates/website/about.html:29
 msgid ""
+"Each Python workshop starts with initial meeting, during\n"
+"    which participants vote on which project they want to work during this "
+"workshop.\n"
+"    The initial meeting is a bit longer than usual meetings and is mainly "
+"devoted\n"
+"    to clarify aims and user stories for the chosen project."
+msgstr ""
+
+#: website/templates/website/about.html:34
+msgid ""
 "Intellectual property and source code created during Python\n"
 "    workshops by participants belong to Python workshops."
 msgstr ""
 "Python dirbtuvių metu padarytų dalyvių intelektualinių ir programinio kodo "
 "įnašų autorinės teisės priklauso Python dirbtuvėms."
 
-#: website/templates/website/about.html:32
+#: website/templates/website/about.html:37
 msgid ""
 "Python workshop's strategical and financial solutions are\n"
 "    made democratically: Python workshops participants vote and majority's "
@@ -83,25 +93,21 @@ msgstr ""
 "demokratiškai: balsuojant Python dirbtuvių dalyviams ir vykdant daugumos "
 "valią."
 
-#: website/templates/website/about.html:36
+#: website/templates/website/about.html:41
 msgid "Each Python workshops participant has to:"
 msgstr "Python dirbtuvių dalyviai turi:"
 
-#: website/templates/website/about.html:38
+#: website/templates/website/about.html:43
 msgid "Accept open source and open knowledge ideologies."
 msgstr "Pritarti atviro kodo ir atvirų žinių ideologijoms."
 
-#: website/templates/website/about.html:39
+#: website/templates/website/about.html:44
 msgid ""
 "Respect and protect human rights and liberties.\n"
-"          Especially right for pricacy."
+"          Especially right for privacy."
 msgstr "Gerbti ir saugoti žmonių teises ir laisves. Ypač teisę į privatumą."
 
-#: website/templates/website/about.html:41
-msgid "Respect Lithuania and foster its prosperity."
-msgstr "Gerbti Lietuvą ir puoselėti jos gerbūvį."
-
-#: website/templates/website/about.html:44
+#: website/templates/website/about.html:48
 msgid ""
 "Python workshops participants can suggest ideas, which\n"
 "    could be implemented during Python workshops."
@@ -109,7 +115,7 @@ msgstr ""
 "Python dirbtuvių dalyviai gali siūlyti idėjas, kurias būtų galima realizuoti "
 "Python dirbtuvių metu."
 
-#: website/templates/website/about.html:47
+#: website/templates/website/about.html:51
 msgid ""
 "Good quality open source code is created during Python\n"
 "    workshops, hence projects are released under open source licences, "
@@ -120,7 +126,7 @@ msgstr ""
 "išeities kodas pateikiamas su atviro kodo licencija, jeigu Python dirbtuvių "
 "dalyviai nenusprendžia kitaip."
 
-#: website/templates/website/about.html:51
+#: website/templates/website/about.html:55
 msgid ""
 "Income from Python workshops projects has to be\n"
 "    allocated only for Python workshops community's prosper. For example,\n"
@@ -135,16 +141,15 @@ msgstr ""
 "sąnaudos, taip pat gali būti samdomi etatiniai Python dirbtuvių "
 "programuotojai."
 
-#: website/templates/website/about.html:57
-msgid ""
-"All financial operations have to be provided openly in\n"
-"    computer friendly format to guarantee transparency. All expenses have "
-"to\n"
-"    be rational, substantiated and approved by the majority of Python "
-"workshops\n"
-"    participants."
-msgstr ""
-"Visos finansinės operacijos turi būti pateikiamos viešai kompiuteriniu "
-"formatu, kad būtų užtikrintas skaidrumas. Visos sąnaudos turi būti "
-"racionalios ir pagrįstos bei joms turi pritarti Python dirbtuvių dalyvių "
-"dauguma."
+#~ msgid ""
+#~ "All financial operations have to be provided openly in\n"
+#~ "    computer friendly format to guarantee transparency. All expenses have "
+#~ "to\n"
+#~ "    be rational, substantiated and approved by the majority of Python "
+#~ "workshops\n"
+#~ "    participants."
+#~ msgstr ""
+#~ "Visos finansinės operacijos turi būti pateikiamos viešai kompiuteriniu "
+#~ "formatu, kad būtų užtikrintas skaidrumas. Visos sąnaudos turi būti "
+#~ "racionalios ir pagrįstos bei joms turi pritarti Python dirbtuvių dalyvių "
+#~ "dauguma."

--- a/pylab/locale/lt/LC_MESSAGES/django.po
+++ b/pylab/locale/lt/LC_MESSAGES/django.po
@@ -1,0 +1,150 @@
+# This file is distributed under the same license as the pylab-lt package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 1.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-27 03:04-0500\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: Lithuanian\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
+"%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: website/menus.py:19
+msgid "About"
+msgstr "Apie"
+
+#: website/templates/website/about.html:7
+msgid "About Summer Python Workshop"
+msgstr "Apie Vasaros Python dirbtuves"
+
+#: website/templates/website/about.html:9
+msgid ""
+"During this event everybody can learn how to program in\n"
+"    Python and Django by creating <a href=\"http://pylab.lt\">pylab.lt</a>\n"
+"    website."
+msgstr ""
+"Šio renginio metu visi norintys gali mokytis programuoti su Python ir "
+"Django, kurdami <a href=\"http://pylab.lt\">pylab.lt</a> svetainę."
+
+#: website/templates/website/about.html:13
+msgid ""
+"Every workshop participant has to choose individual task,\n"
+"    which he would be able to complete in one week. Two hours long meeting "
+"is\n"
+"    held each week, during which participants present how they managed to "
+"complete\n"
+"    their tasks and what issues they faced. Advanced programmers give "
+"advices and\n"
+"    help to solve problems during this meeting. Participants can choose next "
+"tasks\n"
+"    if they managed to finish their task successfully."
+msgstr ""
+"Kiekvienas dirbtuvių dalyvis turi pasirinkti individualią užduotį, kurią "
+"atliktų per savaitę. Kiekvieną savaitę vyksta 2 valandų susitikimas, per "
+"kurį dalyviai pristato, kaip įgyvendino savo užduotis, ar su kokiais "
+"sunkumais susidūrė. Šio susitikimo metu patyrę programuotojai pataria bei "
+"padeda išspręsti kilusias problemas.  Sėkmingai užduotį įgyvendinę dalyviai "
+"pasirenka sekančios savaitės užduotis."
+
+#: website/templates/website/about.html:20
+msgid ""
+"\"Summer Python workshop\" meetings are held every Monday\n"
+"    from 18:00 till 20:00 at Čiurlionio g. 13-1."
+msgstr ""
+"„Vasaros Python dirbtuvių“ susitikimas vyksta kiekvieną pirmadienį nuo 18:00 "
+"iki 20:00, Čiurlionio g. 13-1."
+
+#: website/templates/website/about.html:27
+msgid "Python workshops policy"
+msgstr "Python dirbtuvių politika"
+
+#: website/templates/website/about.html:29
+msgid ""
+"Intellectual property and source code created during Python\n"
+"    workshops by participants belong to Python workshops."
+msgstr ""
+"Python dirbtuvių metu padarytų dalyvių intelektualinių ir programinio kodo "
+"įnašų autorinės teisės priklauso Python dirbtuvėms."
+
+#: website/templates/website/about.html:32
+msgid ""
+"Python workshop's strategical and financial solutions are\n"
+"    made democratically: Python workshops participants vote and majority's "
+"will is\n"
+"    executed."
+msgstr ""
+"Python dirbtuvių strateginiai ir finansiniai sprendimai priimami "
+"demokratiškai: balsuojant Python dirbtuvių dalyviams ir vykdant daugumos "
+"valią."
+
+#: website/templates/website/about.html:36
+msgid "Each Python workshops participant has to:"
+msgstr "Python dirbtuvių dalyviai turi:"
+
+#: website/templates/website/about.html:38
+msgid "Accept open source and open knowledge ideologies."
+msgstr "Pritarti atviro kodo ir atvirų žinių ideologijoms."
+
+#: website/templates/website/about.html:39
+msgid ""
+"Respect and protect human rights and liberties.\n"
+"          Especially right for pricacy."
+msgstr "Gerbti ir saugoti žmonių teises ir laisves. Ypač teisę į privatumą."
+
+#: website/templates/website/about.html:41
+msgid "Respect Lithuania and foster its prosperity."
+msgstr "Gerbti Lietuvą ir puoselėti jos gerbūvį."
+
+#: website/templates/website/about.html:44
+msgid ""
+"Python workshops participants can suggest ideas, which\n"
+"    could be implemented during Python workshops."
+msgstr ""
+"Python dirbtuvių dalyviai gali siūlyti idėjas, kurias būtų galima realizuoti "
+"Python dirbtuvių metu."
+
+#: website/templates/website/about.html:47
+msgid ""
+"Good quality open source code is created during Python\n"
+"    workshops, hence projects are released under open source licences, "
+"unless\n"
+"    Python workshops community decide otherwise."
+msgstr ""
+"Python dirbtuvių metu mokomasi kurti kokybišką atvirą kodą, todėl projektų "
+"išeities kodas pateikiamas su atviro kodo licencija, jeigu Python dirbtuvių "
+"dalyviai nenusprendžia kitaip."
+
+#: website/templates/website/about.html:51
+msgid ""
+"Income from Python workshops projects has to be\n"
+"    allocated only for Python workshops community's prosper. For example,\n"
+"    expenses for domains, servers, rent, municipality or hackathon "
+"organization\n"
+"    can be covered, also permanent employees for Python workshops can be\n"
+"    employed."
+msgstr ""
+"Iš Python dirbtuvių projektų surinktos lėšos skiriamos Python dirbtuvių "
+"bendruomenei puoselėti. Pavyzdžiui, gali būti padengiamos projektų domenų, "
+"serverių, patalpų nuomos, komunalinių mokesčių, hakatonų organizavimo "
+"sąnaudos, taip pat gali būti samdomi etatiniai Python dirbtuvių "
+"programuotojai."
+
+#: website/templates/website/about.html:57
+msgid ""
+"All financial operations have to be provided openly in\n"
+"    computer friendly format to guarantee transparency. All expenses have "
+"to\n"
+"    be rational, substantiated and approved by the majority of Python "
+"workshops\n"
+"    participants."
+msgstr ""
+"Visos finansinės operacijos turi būti pateikiamos viešai kompiuteriniu "
+"formatu, kad būtų užtikrintas skaidrumas. Visos sąnaudos turi būti "
+"racionalios ir pagrįstos bei joms turi pritarti Python dirbtuvių dalyvių "
+"dauguma."

--- a/pylab/website/menus.py
+++ b/pylab/website/menus.py
@@ -16,5 +16,6 @@ class Item(object):
 menus = {
     'topmenu': [
         Item(_('Vasaros Python dirbtuvės'), 'project-list'),
+        Item(_('About'), 'about'),
     ],
 }

--- a/pylab/website/static/css/main.scss
+++ b/pylab/website/static/css/main.scss
@@ -22,3 +22,19 @@
 .page-actions > .btn {
     margin-right: 12px;
 }
+
+.about {
+    margin: 0 auto;
+    margin-bottom: 200px;
+    max-width: 900px;
+    overflow: hidden;
+    padding: 10px;
+    font-size: 14px;
+    font-family: sans-serif;
+    h1 {
+        color: #1c3b56;
+        font-size: 30px;
+        font-weight: normal;
+        margin-top: 20px;
+    }
+}

--- a/pylab/website/templates/website/about.html
+++ b/pylab/website/templates/website/about.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% load trans blocktrans from i18n %}
+
+
+{% block content %}
+  <div class="about">
+    <h1>{% trans "About Summer Python Workshop" %}</h1>
+
+    <p>{% blocktrans %}During this event everybody can learn how to program in
+    Python and Django by creating <a href="http://pylab.lt">pylab.lt</a>
+    website.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}Every workshop participant has to choose individual task,
+    which he would be able to complete in one week. Two hours long meeting is
+    held each week, during which participants present how they managed to complete
+    their tasks and what issues they faced. Advanced programmers give advices and
+    help to solve problems during this meeting. Participants can choose next tasks
+    if they managed to finish their task successfully.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}"Summer Python workshop" meetings are held every Monday
+    from 18:00 till 20:00 at Čiurlionio g. 13-1.{% endblocktrans %}</p>
+
+    <iframe width="830" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0"
+    src="http://www.openstreetmap.org/export/embed.html?bbox=25.26177942752838%2C54.68205628977621%2C25.264630615711212%2C54.68296184199744&amp;layer=mapnik&amp;marker=54.6825090684119%2C25.263205021619797"
+    style="border: 1px solid black"></iframe>
+
+    <h1>{% trans "Python workshops policy" %}</h1>
+
+    <p>{% blocktrans %}Intellectual property and source code created during Python
+    workshops by participants belong to Python workshops.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}Python workshop's strategical and financial solutions are
+    made democratically: Python workshops participants vote and majority's will is
+    executed.{% endblocktrans %}<p>
+
+    <p>{% trans "Each Python workshops participant has to:" %}
+    <ul>
+      <li>{% trans "Accept open source and open knowledge ideologies." %}</li>
+      <li>{% blocktrans %}Respect and protect human rights and liberties.
+          Especially right for pricacy.{% endblocktrans %}</li>
+      <li>{% trans "Respect Lithuania and foster its prosperity." %}</li>
+    </ul></p>
+
+    <p>{% blocktrans %}Python workshops participants can suggest ideas, which
+    could be implemented during Python workshops.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}Good quality open source code is created during Python
+    workshops, hence projects are released under open source licences, unless
+    Python workshops community decide otherwise.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}Income from Python workshops projects has to be
+    allocated only for Python workshops community's prosper. For example,
+    expenses for domains, servers, rent, municipality or hackathon organization
+    can be covered, also permanent employees for Python workshops can be
+    employed.{% endblocktrans %}</p>
+
+    <p>{% blocktrans %}All financial operations have to be provided openly in
+    computer friendly format to guarantee transparency. All expenses have to
+    be rational, substantiated and approved by the majority of Python workshops
+    participants.{% endblocktrans %}</p>
+
+</div>
+{% endblock %}

--- a/pylab/website/templates/website/about.html
+++ b/pylab/website/templates/website/about.html
@@ -21,10 +21,15 @@
     from 18:00 till 20:00 at Čiurlionio g. 13-1.{% endblocktrans %}</p>
 
     <iframe width="830" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0"
-    src="http://www.openstreetmap.org/export/embed.html?bbox=25.26177942752838%2C54.68205628977621%2C25.264630615711212%2C54.68296184199744&amp;layer=mapnik&amp;marker=54.6825090684119%2C25.263205021619797"
+    src="http://www.openstreetmap.org/export/embed.html?bbox=25.25760054588318%2C54.67979232084423%2C25.268651247024533%2C54.685194624174684&amp;layer=mapnik&amp;marker=54.682490461170204%2C25.263125896453857"
     style="border: 1px solid black"></iframe>
 
     <h1>{% trans "Python workshops policy" %}</h1>
+
+    <p>{% blocktrans %}Each Python workshop starts with initial meeting, during
+    which participants vote on which project they want to work during this workshop.
+    The initial meeting is a bit longer than usual meetings and is mainly devoted
+    to clarify aims and user stories for the chosen project.{% endblocktrans %}</p> 
 
     <p>{% blocktrans %}Intellectual property and source code created during Python
     workshops by participants belong to Python workshops.{% endblocktrans %}</p>
@@ -37,8 +42,7 @@
     <ul>
       <li>{% trans "Accept open source and open knowledge ideologies." %}</li>
       <li>{% blocktrans %}Respect and protect human rights and liberties.
-          Especially right for pricacy.{% endblocktrans %}</li>
-      <li>{% trans "Respect Lithuania and foster its prosperity." %}</li>
+          Especially right for privacy.{% endblocktrans %}</li>
     </ul></p>
 
     <p>{% blocktrans %}Python workshops participants can suggest ideas, which
@@ -54,10 +58,10 @@
     can be covered, also permanent employees for Python workshops can be
     employed.{% endblocktrans %}</p>
 
-    <p>{% blocktrans %}All financial operations have to be provided openly in
-    computer friendly format to guarantee transparency. All expenses have to
-    be rational, substantiated and approved by the majority of Python workshops
-    participants.{% endblocktrans %}</p>
+    {# <p>{% blocktrans %}All financial operations have to be provided openly in #}
+    {# computer friendly format to guarantee transparency. All expenses have to #}
+    {# be rational, substantiated and approved by the majority of Python workshops #}
+    {# participants.{% endblocktrans %}</p> #}
 
 </div>
 {% endblock %}

--- a/pylab/website/urls.py
+++ b/pylab/website/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     url(r'^projects/create/$', views.project_create, name='create-project'),
     url(r'^projects/(?P<project_slug>%s)/$' % slug, views.project_details, name='project-details'),
     url(r'^projects/(?P<project_slug>%s)/update/$' % slug, views.project_update, name='project-update'),
+    url(r'^about/$', views.about, name='about'),
 ]
 
 urlpatterns += [

--- a/pylab/website/views.py
+++ b/pylab/website/views.py
@@ -61,3 +61,7 @@ def project_update(request, project_slug):
     return render(request, 'website/project_form.html', {
         'form': formrenderer.render(request, form, title=project.title, submit=ugettext('Submit')),
     })
+
+
+def about(request):
+    return render(request, 'website/about.html', {})


### PR DESCRIPTION
Bouth "Summar Python Workshop" description and "Python workshops" policy are
provided in this static pylab.lt about page.

In the future "Summar Python Workshop" description should be moved to Event instance.