### PR TITLE
Show address and map only if specified

### DIFF
--- a/pylab/website/templates/website/event_details.html
+++ b/pylab/website/templates/website/event_details.html
@@ -7,11 +7,17 @@
 
 <h1>{{ event.title }}</h1>
 
+{% if event.address or event.osm_map_link %}
 <div class="pull-right">
+  {% if event.address %}
   <h3>{{ event.address }}</h3>
+  {% endif %}
+  {% if event.osm_map_link %}
   <iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0"
           src="{{ event.osm_map_link }}" class="border-1px"></iframe>
+  {% endif %}
 </div>
+{% endif %}
 
 <h3>{{ event.starts|date:'Y-m-d' }}
 {% if event.starts.date == event.ends.date %}


### PR DESCRIPTION
Currently empty h3 and iframe was shown if address or map was not
specified.

A fix to #22.