### PR TITLE
Update default site to correct value

### DIFF
--- a/pylab/core/__init__.py
+++ b/pylab/core/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'pylab.core.apps.PylabCoreConfig'

--- a/pylab/core/apps.py
+++ b/pylab/core/apps.py
@@ -1,0 +1,13 @@
+from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+from django.utils.translation import ugettext_lazy as _
+
+from pylab.core.management import update_default_site
+
+
+class PylabCoreConfig(AppConfig):
+    name = 'pylab.core'
+    verbose_name = _("Website")
+
+    def ready(self):
+        post_migrate.connect(update_default_site, sender=self)

--- a/pylab/core/management.py
+++ b/pylab/core/management.py
@@ -1,0 +1,12 @@
+from django.apps import apps
+from django.conf import settings
+
+
+def update_default_site(app_config, verbosity=2, **kwargs):
+    Site = apps.get_model('sites', 'Site')
+    site = Site.objects.get_current()
+
+    if site.domain == 'example.com':
+        site.domain = settings.SERVER_NAME
+        site.name = 'pylab.lt'
+        site.save()

--- a/pylab/core/management.py
+++ b/pylab/core/management.py
@@ -2,7 +2,7 @@ from django.apps import apps
 from django.conf import settings
 
 
-def update_default_site(app_config, verbosity=2, **kwargs):
+def update_default_site(app_config, verbosity=2, **kwargs):  # pylint: disable=unused-argument
     Site = apps.get_model('sites', 'Site')
     site = Site.objects.get_current()
 

--- a/pylab/settings/base.py
+++ b/pylab/settings/base.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.auth',
     'django.contrib.messages',
+    'django.contrib.sites',
     'django.contrib.admin',
 )
 
@@ -200,7 +201,6 @@ TEMPLATE_CONTEXT_PROCESSORS += [
 ]
 
 INSTALLED_APPS += (
-    'django.contrib.sites',
     'allauth',
     'allauth.account',
     'allauth.socialaccount',

--- a/pylab/settings/development.py
+++ b/pylab/settings/development.py
@@ -3,3 +3,4 @@
 from pylab.settings.base import *  # noqa
 
 DEBUG = True
+SERVER_NAME = 'localhost:8000'


### PR DESCRIPTION
This will update default site to settings.SERVER_NAME values, which can be
different depending on settings environment.

After running `bin/django migrate` default site will be updated.

It is imported that 'django.contrib.sites' should be added first in
`INSTALLED_APPS`. Not first, but before 'pylab.core'.

Implements #43.